### PR TITLE
Subscription - discount: support discount expiration time

### DIFF
--- a/doc/new-in-v1.2.x.md
+++ b/doc/new-in-v1.2.x.md
@@ -102,3 +102,10 @@ From v1.2.1 17. Subscription period set/extends
 
 -   added the support of the column: started_at
 -   column will be set on subscription creation and when it is extended
+
+17. Subscription Discount
+
+-   support discount expiration time on a subscription
+-   when user is initiating a subscription , can provide an expiration time
+-   when discount is added to subscription, user can provide expiration time
+-   when subscription has discount without expiration, it is a lifetime discount

--- a/src/Models/Subscription.php
+++ b/src/Models/Subscription.php
@@ -19,7 +19,8 @@ class Subscription extends Model
         'expired_at',
         'trial_end_on',
         'canceled_at',
-        'started_at'
+        'started_at',
+        'discount_expired_at',
     ];
 
     const STATUS_FREE_ACTIVE = 'free_active';

--- a/src/Models/Traits/HasSubscription.php
+++ b/src/Models/Traits/HasSubscription.php
@@ -75,10 +75,15 @@ trait HasSubscription
      * Add a discount to the model's subscription
      * 
      * @param string|Discount $discount
+     * @param DateTime|string|Illuminate\Support\Carbon|null $expiredOn
      */
-    public function addSubscriptionDiscount($discount): Subscription
+    public function addSubscriptionDiscount($discount, $expiredOn = null): Subscription
     {
-        return PaymentSub::subscription()->addDiscount($this, $discount);
+        return PaymentSub::subscription()->addDiscount(
+            $this,
+            $discount,
+            $expiredOn
+        );
     }
 
     /**

--- a/src/Services/Subscripion/Action/ToggleSubscriptionDiscountAction.php
+++ b/src/Services/Subscripion/Action/ToggleSubscriptionDiscountAction.php
@@ -12,6 +12,7 @@ class ToggleSubscriptionDiscountAction extends CustomActionBuilder
     {
         $subscription = $data->subscriber->subscription;
         $subscription->discount_id = $data->should_add ? $data->discount?->id : null;
+        $subscription->discount_expired_at = $data->discount_expired_at;
         $subscription->save();
 
         return  $subscription;

--- a/src/Services/Subscripion/Data/CreateSubscriptionData.php
+++ b/src/Services/Subscripion/Data/CreateSubscriptionData.php
@@ -13,6 +13,7 @@ use Kakaprodo\PaymentSubscription\Models\Traits\HasSubscription;
  * @property PaymentPlan $plan
  * @property HasSubscription $subscriber
  * @property Discount $discount
+ * @property DateTime|string|Illuminate\Support\Carbon|null $discount_expired_at
  * @property DateTime|string|Illuminate\Support\Carbon $expired_at
  * @property DateTime|string|Illuminate\Support\Carbon $trial_end_on
  * @property DateTime|string|Illuminate\Support\Carbon $started_at
@@ -35,6 +36,7 @@ class CreateSubscriptionData extends BaseData
                 ->castTo(
                     fn($discount) => is_string($discount) ? Discount::getOrFail($discount) : $discount
                 ),
+            'discount_expired_at?',
             'is_trial' => $this->property()->bool(false),
             'trial_end_on?' => $this->property()->castTo(
                 fn($trialPeriod) => !$this->is_trial ? null : (
@@ -72,6 +74,7 @@ class CreateSubscriptionData extends BaseData
             'status' =>  $this->detectSubscriptionStatus(),
             'plan_id' => $this->plan->id,
             'discount_id' => $this->discount?->id,
+            'discount_expired_at' => $this->discount_expired_at,
             'expired_at' => $this->expired_at,
             'trial_end_on' =>  $this->trial_end_on,
             'started_at' => $this->started_at

--- a/src/Services/Subscripion/Data/SubscriptionCostData.php
+++ b/src/Services/Subscripion/Data/SubscriptionCostData.php
@@ -2,6 +2,7 @@
 
 namespace Kakaprodo\PaymentSubscription\Services\Subscripion\Data;
 
+use Carbon\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Kakaprodo\PaymentSubscription\Helpers\Util;
@@ -60,13 +61,24 @@ class SubscriptionCostData extends BaseData
     public function boot()
     {
         $this->plan = $this->subscription->plan;
-        $this->discount = $this->subscription->discount_id ? $this->subscription->discount : null;
+        $this->discount = $this->getDiscount();
 
         // load cost from consumptions list
         $this->shortConsumptionList();
 
         // load cost from activated features
         $this->loadActivatedFeatureCost();
+    }
+
+    private function getDiscount()
+    {
+        if (!$this->subscription->discount_id) return;
+
+        $discount = $this->subscription->discount;
+
+        if (!$this->subscription->discount_expired_at) return  $discount;
+
+        return  Carbon::parse($this->subscription->discount_expired_at)->isPast() ? null : $discount;
     }
 
     public function loadActivatedFeatureCost()

--- a/src/Services/Subscripion/Data/ToggleSubscriptionDiscountData.php
+++ b/src/Services/Subscripion/Data/ToggleSubscriptionDiscountData.php
@@ -12,6 +12,7 @@ use Kakaprodo\PaymentSubscription\Models\Traits\HasSubscription;
  * @property HasSubscription $subscriber
  * @property Discount $discount
  * @property bool $should_add
+ * @property DateTime|string|Illuminate\Support\Carbon|null $discount_expired_at
  */
 class ToggleSubscriptionDiscountData extends BaseData
 {
@@ -26,7 +27,13 @@ class ToggleSubscriptionDiscountData extends BaseData
                 ->castTo(
                     fn($discount) => is_string($discount) ? Discount::getOrFail($discount) : $discount
                 ),
+            'discount_expired_at?',
             'should_add' => $this->property()->bool(true)
         ];
+    }
+
+    public function boot()
+    {
+        $this->deleteCachedSubscriptionCostKey($this->subscriber);
     }
 }

--- a/src/Services/Subscripion/SubscripionService.php
+++ b/src/Services/Subscripion/SubscripionService.php
@@ -40,13 +40,15 @@ class SubscripionService extends ServiceBase
      * 
      * @param Model $subscriber
      * @param string|Discount $discount
+     * @param DateTime|string|Illuminate\Support\Carbon|null $expiredOn
      */
-    public function addDiscount(Model $subscriber, $discount): Subscription
+    public function addDiscount(Model $subscriber, $discount, $expiredOn = null): Subscription
     {
         return ToggleSubscriptionDiscountAction::process([
             'subscriber' => $subscriber,
             'discount' => $discount,
-            'should_add' => true
+            'should_add' => true,
+            'discount_expired_at' => $expiredOn,
         ]);
     }
 

--- a/src/database/migrations/2025_02_24_195314_add_discount_expired_at_to_subscriptions.php
+++ b/src/database/migrations/2025_02_24_195314_add_discount_expired_at_to_subscriptions.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use Kakaprodo\PaymentSubscription\Models\Subscription;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table((new Subscription())->getTable(), function (Blueprint $table) {
+            $table->date('discount_expired_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table((new Subscription())->getTable(), function (Blueprint $table) {
+            $table->dropColumn('discount_expired_at');
+        });
+    }
+};


### PR DESCRIPTION
## work done:
Subscription Discount

-   support discount expiration time on a subscription
-   when user is initiating a subscription , can provide an expiration time
-   when discount is added to subscription, user can provide expiration time
-   when subscription has discount without expiration, it is a lifetime discount